### PR TITLE
Fixed range for rows to skip in "BLU01 Dealing with larger datasets"

### DIFF
--- a/S02 - Data Wrangling/BLU01 - Messy Data/Learning Notebook - Part 3 of 3 - Dealing with larger datasets.ipynb
+++ b/S02 - Data Wrangling/BLU01 - Messy Data/Learning Notebook - Part 3 of 3 - Dealing with larger datasets.ipynb
@@ -568,7 +568,7 @@
     "\n",
     "random.seed(42) # this is to get always the same sample. can be removed if we want the sample to change\n",
     "rows_to_skip = random.sample(\n",
-    "    range(1, lines_in_file-1), # this is a range from the first row after the header, to the last row on the file\n",
+    "    range(1, lines_in_file+1), # this is a range from the first row after the header, to the last row on the file\n",
     "    n_rows_to_skip # this is the number of rows we want to random sample here, and that we will be skipped on pd.read_csv with argument skiprows\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Range was only until `lines_in_file-1`, which meant the last two lines (799 and 800) were never skipped.